### PR TITLE
fix: invalid deployment instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,11 +55,11 @@ In this example we will be publishing the Next.js app to [Vercel](https://vercel
 3. Deploy your app to Vercel. You can follow the guide [here](https://vercel.com/docs/concepts/deployments/git).
 4. While deploying make sure to set the environment variable `OPENAI_API_KEY` to your OpenAI API key.
    ![Photo of environment variable editor](https://static.figma.com/uploads/e41166e6a4e0d9c9c90bf662a609396ab7fe33cc)
-5. Once your app is deployed you can update the `siteURL` section of your `package.json` file to point to the deployed URL. It will look something like `https://your-site-here.vercel.app/`
+5. Once your app is deployed you can update the `siteURL` section of your `package.json` file to point to the deployed URL. It will look something like `https://your-site-here.vercel.app`
 
 ```json
 "config": {
-  "siteURL": "https://your-site-here.vercel.app/"
+  "siteURL": "https://your-site-here.vercel.app"
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -36,6 +36,6 @@
     "concurrently": "^8.2.0"
   },
   "config": {
-    "siteURL": "https://test-ai-plugin-template.vercel.app/"
+    "siteURL": "https://test-ai-plugin-template.vercel.app"
   }
 }


### PR DESCRIPTION
The Vercel deployment instructions include a trailing slash, which causes the origin checks in onmessage (dd2b2c59183b39903ef264616d8b3f862a7435df) to fail due to `props.origin` not including this trailing slash. This causes the onmessage handler to return early and none of the code there to be executed.

This PR introduces a small change to the deployment instructions to account for origin checking & updates package.json to remove the trailing slash from siteURL.